### PR TITLE
Restructure HTML prototype into modular project

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,46 @@
+body {
+    font-family: 'Inter', sans-serif;
+    overflow: hidden;
+}
+#main-container {
+    display: flex;
+    width: 100vw;
+    height: 100vh;
+}
+#canvas-container {
+    flex-grow: 1;
+    position: relative;
+    min-width: 0;
+}
+#ui-panel-wrapper {
+    flex-shrink: 0;
+    width: 0;
+    overflow: hidden;
+}
+#ui-panel {
+    width: 24rem;
+    height: 100%;
+}
+canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+/* Custom scrollbar for the panel */
+.custom-scrollbar::-webkit-scrollbar { width: 5px; }
+.custom-scrollbar::-webkit-scrollbar-track { background: rgba(255, 255, 255, 0.1); border-radius: 10px; }
+.custom-scrollbar::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.3); border-radius: 10px; }
+.custom-scrollbar::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.5); }
+.panel-section-header { cursor: pointer; user-select: none; }
+.chevron { transition: transform 0.2s ease-in-out; }
+.collapsed .chevron { transform: rotate(-90deg); }
+/* Style for the color input */
+input[type="color"] { -webkit-appearance: none; width: 40px; height: 24px; border: none; cursor: pointer; border-radius: 6px; }
+input[type="color"]::-webkit-color-swatch-wrapper { padding: 0; }
+input[type="color"]::-webkit-color-swatch { border: 1px solid rgba(255,255,255,0.2); border-radius: 6px; }
+/* Custom Toggle Switch */
+.toggle-checkbox:checked { right: 0; border-color: #4A5568; }
+.toggle-checkbox:checked + .toggle-label { background-color: #4A5568; }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Landscape Generator</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/styles.css">
+</head>
+<body class="bg-gray-900 text-white">
+
+<div id="main-container">
+    <div id="canvas-container">
+        <button id="options-button" class="absolute top-4 right-4 bg-gray-800/80 backdrop-blur-sm text-white text-sm font-medium py-2 px-4 rounded-lg shadow-lg hover:bg-gray-700/90 transition-colors z-10">Options</button>
+    </div>
+
+    <div id="ui-panel-wrapper">
+        <div id="ui-panel" class="bg-gray-900 bg-opacity-80 backdrop-blur-sm shadow-2xl flex flex-col">
+            <div class="flex-grow p-3 overflow-y-auto custom-scrollbar">
+                <div class="text-center mb-5 relative">
+                    <h1 class="text-xl font-bold text-gray-100">Landscape Generator</h1>
+                    <button id="close-panel-button" class="absolute top-0 right-0 p-1 text-gray-400 hover:text-white transition-colors">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                    </button>
+                </div>
+
+                <div class="bg-gray-800/50 rounded-lg overflow-hidden panel-section collapsed">
+                    <div class="panel-section-header flex justify-between items-center p-2.5 hover:bg-gray-700/50">
+                        <h2 class="text-base font-semibold text-gray-200">Global Settings</h2>
+                        <svg class="chevron w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                    </div>
+                    <div class="panel-section-content p-3 border-t border-gray-700 hidden">
+                        <div class="space-y-3">
+                            <div>
+                                <label for="mesh-detail" class="block text-xs font-medium text-gray-300">Mesh Detail</label>
+                                <input id="mesh-detail" type="range" min="32" max="256" value="128" step="16" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                                <span id="mesh-detail-value" class="text-xs text-gray-400">128x128</span>
+                            </div>
+                            <div>
+                                <label for="texture-detail" class="block text-xs font-medium text-gray-300">Texture Detail</label>
+                                <input id="texture-detail" type="range" min="256" max="2048" value="1024" step="256" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                                <span id="texture-detail-value" class="text-xs text-gray-400">1024px</span>
+                            </div>
+                            <div>
+                                <label class="block text-xs font-medium text-gray-300">World Size</label>
+                                <p class="text-sm text-gray-200">2000m x 2000m</p>
+                            </div>
+                            <div class="flex justify-between items-center">
+                                <label for="bg-color" class="block text-xs font-medium text-gray-300">Background & Fog Color</label>
+                                <input id="bg-color" type="color" value="#111827">
+                            </div>
+                            <div class="border-t border-gray-700 my-2"></div>
+                            <div class="flex justify-between items-center">
+                                <label for="grid-toggle" class="block text-xs font-medium text-gray-300">Show Grid</label>
+                                <div class="relative inline-block w-10 mr-2 align-middle select-none transition duration-200 ease-in">
+                                    <input type="checkbox" name="toggle" id="grid-toggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer"/>
+                                    <label for="grid-toggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-600 cursor-pointer"></label>
+                                </div>
+                            </div>
+                            <div>
+                                <label for="grid-size" class="block text-xs font-medium text-gray-300">Grid Size</label>
+                                <input id="grid-size" type="range" min="10" max="100" value="20" step="10" class="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer">
+                                <span id="grid-size-value" class="text-xs text-gray-400">20 cells</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="space-y-1.5 mt-3">
+                    <div class="bg-gray-800/50 rounded-lg overflow-hidden panel-section collapsed">
+                        <div class="panel-section-header flex justify-between items-center p-2.5 hover:bg-gray-700/50">
+                            <h3 class="font-medium text-sm text-gray-200">Base Shape</h3>
+                            <svg class="chevron w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                        </div>
+                        <div class="panel-section-content p-3 border-t border-gray-700 hidden">
+                            <p class="text-xs text-gray-400">Parameters for the initial landmass shape will go here.</p>
+                        </div>
+                    </div>
+                    <div class="bg-gray-800/50 rounded-lg overflow-hidden panel-section collapsed">
+                        <div class="panel-section-header flex justify-between items-center p-2.5 hover:bg-gray-700/50">
+                            <h3 class="font-medium text-sm text-gray-200">Noise & Distortion</h3>
+                            <svg class="chevron w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                        </div>
+                        <div class="panel-section-content p-3 border-t border-gray-700 hidden">
+                            <p class="text-xs text-gray-400">Controls for adding Perlin, Simplex, or other noise types.</p>
+                        </div>
+                    </div>
+                    <div class="bg-gray-800/50 rounded-lg overflow-hidden panel-section collapsed">
+                        <div class="panel-section-header flex justify-between items-center p-2.5 hover:bg-gray-700/50">
+                            <h3 class="font-medium text-sm text-gray-200">Rock Formations</h3>
+                            <svg class="chevron w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                        </div>
+                        <div class="panel-section-content p-3 border-t border-gray-700 hidden">
+                            <p class="text-xs text-gray-400">Parameters for generating cliffs, boulders, and other rock features.</p>
+                        </div>
+                    </div>
+                    <div class="bg-gray-800/50 rounded-lg overflow-hidden panel-section collapsed">
+                        <div class="panel-section-header flex justify-between items-center p-2.5 hover:bg-gray-700/50">
+                            <h3 class="font-medium text-sm text-gray-200">Texturing</h3>
+                            <svg class="chevron w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                        </div>
+                        <div class="panel-section-content p-3 border-t border-gray-700 hidden">
+                            <p class="text-xs text-gray-400">Define textures based on slope, height, and other factors.</p>
+                        </div>
+                    </div>
+                    <div class="bg-gray-800/50 rounded-lg overflow-hidden panel-section collapsed">
+                        <div class="panel-section-header flex justify-between items-center p-2.5 hover:bg-gray-700/50">
+                            <h3 class="font-medium text-sm text-gray-200">Hydraulic Erosion</h3>
+                            <svg class="chevron w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                        </div>
+                        <div class="panel-section-content p-3 border-t border-gray-700 hidden">
+                            <p class="text-xs text-gray-400">Simulate water flow to create realistic riverbeds and weathering.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script type="importmap">
+    { "imports": { "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js", "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/" } }
+</script>
+<script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/js/config/Settings.js
+++ b/js/config/Settings.js
@@ -1,0 +1,10 @@
+export const Settings = {
+    worldSize: 2000,
+    meshDetail: 128,
+    textureDetail: 1024,
+    backgroundColor: '#111827',
+    grid: {
+        enabled: false,
+        size: 20
+    }
+};

--- a/js/core/Camera.js
+++ b/js/core/Camera.js
@@ -1,0 +1,27 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+export class CameraManager {
+    constructor(container) {
+        const { width, height } = container.getBoundingClientRect();
+        this.camera = new THREE.PerspectiveCamera(60, width / height, 10, 5000);
+        this.camera.position.set(1000, 800, 1000);
+        this.controls = new OrbitControls(this.camera, null);
+        this.controls.target.set(0, 0, 0);
+        this.controls.enableDamping = true;
+        this.controls.dampingFactor = 0.05;
+        this.controls.screenSpacePanning = false;
+        this.controls.minDistance = 200;
+        this.controls.maxDistance = 2500;
+        this.controls.maxPolarAngle = Math.PI / 2.1;
+    }
+
+    attachDomElement(dom) {
+        this.controls.domElement = dom;
+    }
+
+    resize(width, height) {
+        this.camera.aspect = width / height;
+        this.camera.updateProjectionMatrix();
+    }
+}

--- a/js/core/Lighting.js
+++ b/js/core/Lighting.js
@@ -1,0 +1,11 @@
+import * as THREE from 'three';
+
+export function addDefaultLighting(scene) {
+    const ambientLight = new THREE.AmbientLight(0xaaaaaa, 0.8);
+    scene.add(ambientLight);
+
+    const directionalLight = new THREE.DirectionalLight(0xffffff, 1.5);
+    directionalLight.position.set(500, 1000, 300);
+    directionalLight.castShadow = true;
+    scene.add(directionalLight);
+}

--- a/js/core/Renderer.js
+++ b/js/core/Renderer.js
@@ -1,0 +1,14 @@
+import * as THREE from 'three';
+
+export class Renderer {
+    constructor(container) {
+        this.container = container;
+        this.renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
+        this.renderer.setPixelRatio(window.devicePixelRatio);
+        container.appendChild(this.renderer.domElement);
+    }
+
+    setSize(width, height) {
+        this.renderer.setSize(width, height);
+    }
+}

--- a/js/core/Scene.js
+++ b/js/core/Scene.js
@@ -1,0 +1,16 @@
+import * as THREE from 'three';
+
+export class SceneManager {
+    constructor(color) {
+        const c = new THREE.Color(color);
+        this.scene = new THREE.Scene();
+        this.scene.background = c;
+        this.scene.fog = new THREE.Fog(c, 1500, 4000);
+    }
+
+    setBackground(color) {
+        const c = new THREE.Color(color);
+        this.scene.background = c;
+        if (this.scene.fog) this.scene.fog.color = c;
+    }
+}

--- a/js/generators/BaseShape.js
+++ b/js/generators/BaseShape.js
@@ -1,0 +1,5 @@
+export class BaseShape {
+    constructor() {
+        console.log('BaseShape module loaded - implementation pending');
+    }
+}

--- a/js/generators/NoiseGenerator.js
+++ b/js/generators/NoiseGenerator.js
@@ -1,0 +1,5 @@
+export class NoiseGenerator {
+    constructor() {
+        console.log('NoiseGenerator module loaded - implementation pending');
+    }
+}

--- a/js/generators/RockFormations.js
+++ b/js/generators/RockFormations.js
@@ -1,0 +1,5 @@
+export class RockFormations {
+    constructor() {
+        console.log('RockFormations module loaded - implementation pending');
+    }
+}

--- a/js/generators/TerrainGenerator.js
+++ b/js/generators/TerrainGenerator.js
@@ -1,0 +1,46 @@
+import * as THREE from 'three';
+
+export class TerrainGenerator {
+    constructor(scene, worldSize = 2000) {
+        this.scene = scene;
+        this.worldSize = worldSize;
+        this.terrainMesh = null;
+        this.gridHelper = null;
+    }
+
+    generate(meshDetail) {
+        if (this.terrainMesh) {
+            this.scene.remove(this.terrainMesh);
+            this.terrainMesh.geometry.dispose();
+            this.terrainMesh.material.dispose();
+        }
+        const geometry = new THREE.PlaneGeometry(this.worldSize, this.worldSize, meshDetail - 1, meshDetail - 1);
+        geometry.rotateX(-Math.PI / 2);
+        const vertices = geometry.attributes.position.array;
+        for (let i = 0; i < vertices.length; i += 3) {
+            const randomHeight = (Math.random() - 0.5) * 250;
+            const ruggedness = Math.random() * 80;
+            vertices[i + 1] = randomHeight + ruggedness * Math.sin(vertices[i] / 200) * Math.cos(vertices[i + 2] / 200);
+        }
+        geometry.attributes.position.needsUpdate = true;
+        geometry.computeVertexNormals();
+        const material = new THREE.MeshStandardMaterial({ color: 0x556B2F, roughness: 0.8, metalness: 0.2 });
+        this.terrainMesh = new THREE.Mesh(geometry, material);
+        this.terrainMesh.receiveShadow = true;
+        this.scene.add(this.terrainMesh);
+    }
+
+    updateGrid(size, visible) {
+        if (this.gridHelper) {
+            this.scene.remove(this.gridHelper);
+            this.gridHelper.geometry.dispose();
+            this.gridHelper.material.dispose();
+        }
+        this.gridHelper = new THREE.GridHelper(this.worldSize, size, 0xffffff, 0xffffff);
+        this.gridHelper.material.opacity = 0.2;
+        this.gridHelper.material.transparent = true;
+        this.gridHelper.position.y = 0.1;
+        this.gridHelper.visible = visible;
+        this.scene.add(this.gridHelper);
+    }
+}

--- a/js/generators/TextureGenerator.js
+++ b/js/generators/TextureGenerator.js
@@ -1,0 +1,5 @@
+export class TextureGenerator {
+    constructor() {
+        console.log('TextureGenerator module loaded - implementation pending');
+    }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,82 @@
+import { SceneManager } from './core/Scene.js';
+import { Renderer } from './core/Renderer.js';
+import { CameraManager } from './core/Camera.js';
+import { addDefaultLighting } from './core/Lighting.js';
+import { UIManager } from './ui/UIManager.js';
+import { TerrainGenerator } from './generators/TerrainGenerator.js';
+import { Settings } from './config/Settings.js';
+
+const canvasContainer = document.getElementById('canvas-container');
+const bgColorPicker = document.getElementById('bg-color');
+const panelWrapper = document.getElementById('ui-panel-wrapper');
+const optionsButton = document.getElementById('options-button');
+const closePanelButton = document.getElementById('close-panel-button');
+
+const sceneMgr = new SceneManager(Settings.backgroundColor);
+const renderer = new Renderer(canvasContainer);
+const cameraMgr = new CameraManager(canvasContainer);
+cameraMgr.attachDomElement(renderer.renderer.domElement);
+addDefaultLighting(sceneMgr.scene);
+
+const terrain = new TerrainGenerator(sceneMgr.scene, Settings.worldSize);
+terrain.generate(Settings.meshDetail);
+terrain.updateGrid(Settings.grid.size, Settings.grid.enabled);
+
+const ui = new UIManager(panelWrapper, optionsButton, closePanelButton);
+
+function onResize() {
+    const { width, height } = canvasContainer.getBoundingClientRect();
+    if (width > 0 && height > 0) {
+        cameraMgr.resize(width, height);
+        renderer.setSize(width, height);
+    }
+}
+
+const resizeObserver = new ResizeObserver(onResize);
+resizeObserver.observe(canvasContainer);
+// ensure renderer starts at correct size
+onResize();
+
+// UI events
+
+document.getElementById('mesh-detail').addEventListener('input', e => {
+    document.getElementById('mesh-detail-value').textContent = `${e.target.value}x${e.target.value}`;
+});
+
+document.getElementById('mesh-detail').addEventListener('change', e => {
+    terrain.generate(parseInt(e.target.value));
+});
+
+document.getElementById('texture-detail').addEventListener('input', e => {
+    document.getElementById('texture-detail-value').textContent = `${e.target.value}px`;
+});
+
+bgColorPicker.addEventListener('input', e => {
+    sceneMgr.setBackground(e.target.value);
+});
+
+document.getElementById('grid-toggle').addEventListener('change', e => {
+    if (terrain.gridHelper) terrain.gridHelper.visible = e.target.checked;
+});
+
+document.getElementById('grid-size').addEventListener('input', e => {
+    document.getElementById('grid-size-value').textContent = `${e.target.value} cells`;
+});
+
+document.getElementById('grid-size').addEventListener('change', e => {
+    terrain.updateGrid(parseInt(e.target.value), document.getElementById('grid-toggle').checked);
+});
+
+let lastTime = 0;
+function animate(time) {
+    const delta = (time - lastTime) / 1000;
+    lastTime = time;
+
+    const changed = ui.update(delta);
+    if (changed) onResize();
+
+    cameraMgr.controls.update();
+    renderer.renderer.render(sceneMgr.scene, cameraMgr.camera);
+}
+
+renderer.renderer.setAnimationLoop(animate);

--- a/js/ui/UIComponents.js
+++ b/js/ui/UIComponents.js
@@ -1,0 +1,4 @@
+// Placeholder for reusable UI components
+export const UIComponents = {
+    // Functions to build sliders, toggles, etc. will go here
+};

--- a/js/ui/UIManager.js
+++ b/js/ui/UIManager.js
@@ -1,0 +1,37 @@
+export class UIManager {
+    constructor(panelWrapper, optionsBtn, closeBtn) {
+        this.panelWrapper = panelWrapper;
+        this.optionsBtn = optionsBtn;
+        this.closeBtn = closeBtn;
+        this.panelWidthPx = 24 * 16; // 24rem
+        this.currentWidth = 0;
+        this.targetWidth = 0;
+
+        this.optionsBtn.addEventListener('click', () => this.open());
+        this.closeBtn.addEventListener('click', () => this.close());
+
+        document.querySelectorAll('.panel-section-header').forEach(header => {
+            header.addEventListener('click', () => {
+                const section = header.closest('.panel-section');
+                section.classList.toggle('collapsed');
+                section.querySelector('.panel-section-content').classList.toggle('hidden');
+            });
+        });
+    }
+
+    open() { this.targetWidth = this.panelWidthPx; }
+    close() { this.targetWidth = 0; }
+
+    update(delta) {
+        const needsUpdate = Math.abs(this.currentWidth - this.targetWidth) > 0.1;
+        if (needsUpdate) {
+            const speed = 10;
+            const diff = this.targetWidth - this.currentWidth;
+            this.currentWidth += diff * speed * delta;
+            if (Math.abs(diff) < 0.5) this.currentWidth = this.targetWidth;
+            this.panelWrapper.style.width = `${this.currentWidth}px`;
+        }
+        this.optionsBtn.style.display = this.currentWidth < 1 ? 'block' : 'none';
+        return needsUpdate;
+    }
+}

--- a/js/utils/EventBus.js
+++ b/js/utils/EventBus.js
@@ -1,0 +1,12 @@
+export const EventBus = {
+    events: {},
+    on(event, callback) {
+        if (!this.events[event]) this.events[event] = [];
+        this.events[event].push(callback);
+    },
+    emit(event, data) {
+        if (this.events[event]) {
+            this.events[event].forEach(cb => cb(data));
+        }
+    }
+};

--- a/js/utils/MathUtils.js
+++ b/js/utils/MathUtils.js
@@ -1,0 +1,4 @@
+// Placeholder for common math utilities
+export const MathUtils = {
+    // Future math functions will go here
+};


### PR DESCRIPTION
## Summary
- create `index.html` and copy UI from original prototype
- move all inline CSS to `css/styles.css`
- add modular JavaScript structure under `js/`
  - core modules for scene, camera, renderer and lighting
  - UI manager handling panel animation and section collapse
  - terrain generator module with same functionality as the original
  - placeholder generators and utilities
- include default settings configuration
- call `onResize()` on startup to ensure renderer sizing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c3b411240832db2b6223c4e1493bb